### PR TITLE
Switch to token auth type

### DIFF
--- a/src/components/github.js
+++ b/src/components/github.js
@@ -5,7 +5,7 @@ import request from 'request';
 const github = new GitHubApi(config.github.api);
 if (config.github.token) {
   github.authenticate({
-    type: 'oauth',
+    type: 'token',
     token: config.github.token
   });
 }


### PR DESCRIPTION
https://3.basecamp.com/3439565/buckets/1089865/todos/2832161633

No idea if this works.

# TODO

- [x] Figure out how to test

# Testing

Tested by running the following (with the actual prod github token):

```sh
npm run build && GITHUB_TOKEN=<token> npm start
```

Then hitting this URL: http://lvh.me:3000/download/linux/latest?pkg=deb&arch=x86_64

It still works, but I have no way of confirming that we're not getting the deprecation notice anymore.